### PR TITLE
feat(api): v2.2.0 - improve API safety, diagnostics, and documentation

### DIFF
--- a/custom_components/rachio_local/manifest.json
+++ b/custom_components/rachio_local/manifest.json
@@ -7,5 +7,5 @@
     "documentation": "https://github.com/biofects/rachio_local",
     "iot_class": "cloud_polling",
     "requirements": ["requests>=2.25.1"],
-    "version": "2.1.0"
+    "version": "2.2.0"
 }

--- a/custom_components/rachio_local/utils.py
+++ b/custom_components/rachio_local/utils.py
@@ -17,7 +17,7 @@ def get_update_interval(handler) -> timedelta:
             if remaining := schedule.get("remaining", 0):
                 remaining_mins = max(remaining_mins, remaining / 60)
     if not active:
-        return timedelta(minutes=30)
+        return timedelta(minutes=5)  # Changed from 30 to 5 minutes
     elif remaining_mins < 1:
         return timedelta(seconds=10)
     elif remaining_mins < 5:


### PR DESCRIPTION
- Updated Schedules for control Start and Stop
- Limit initial fast polling to 3x 30s intervals on startup, then switch to dynamic (5 min) polling when idle to reduce API usage and avoid rate limits
- Add API diagnostics sensor: exposes API call count, rate limit, remaining calls, and reset time (in local time) for each device
- Track and update API usage and rate limit info in handler classes for accurate diagnostics
- Show API rate reset time in local timezone in sensor attributes