### PR TITLE
Bump version to v2.4.0 and update HACS domains

### DIFF
--- a/custom_components/rachio_local/manifest.json
+++ b/custom_components/rachio_local/manifest.json
@@ -7,5 +7,5 @@
     "documentation": "https://github.com/biofects/rachio_local",
     "iot_class": "cloud_polling",
     "requirements": ["requests>=2.25.1"],
-    "version": "2.3.1"
+    "version": "2.4.0"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -2,7 +2,7 @@
   "name": "Rachio Local Control",
   "content_in_root": false,
   "render_readme": true,
-  "domains": ["switch", "sensor"],
+  "domains": ["switch", "sensor", "select"],
   "homeassistant": "2025.6.1",
   "country": "US",
   "iot_class": "cloud_polling"


### PR DESCRIPTION
- Updated manifest.json version to 2.4.0
- Added 'select' domain to hacs.json for rain delay duration entity
- Preparing for v2.4.0 release with Smart Hose Timer enhancements