### PR TITLE
fix: Remove duplicate 'fields' key in update_program service definition

### DIFF
--- a/custom_components/rachio_local/services.yaml
+++ b/custom_components/rachio_local/services.yaml
@@ -357,7 +357,6 @@ update_program:
   #   device:
   #     integration: rachio_local #Removed due HASSFest change on 15OCT.  https://developers.home-assistant.io/blog/2025/10/14/device-filter-removed-from-target-selector
   fields:
-  fields:
     program_id:
       name: Program
       description: "Select a program sensor (entities starting with 'Program:')"


### PR DESCRIPTION
Removed duplicate 'fields' key in update_program service definition.

This should close #25 